### PR TITLE
feat: Support Kotlin 2.1.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.0.0"
+    kotlin("jvm") version "2.1.20"
 }
 
 buildscript {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPluginRegistrar.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPluginRegistrar.kt
@@ -6,13 +6,11 @@ import io.github.tabilzad.ktor.k2.SwaggerDeclarationChecker
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
-import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension.Factory
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 
@@ -23,7 +21,6 @@ open class KtorMetaPluginRegistrar : CompilerPluginRegistrar() {
 
     @OptIn(ExperimentalCompilerApi::class)
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-        configuration.put(JVMConfigurationKeys.IR, true)
         val config = configuration.buildPluginConfiguration()
         // K1
         StorageComponentContainerContributor.registerExtension(DeclarationExtension(config))

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassDescriptorVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassDescriptorVisitorK2.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.fir.declarations.utils.isSealed
 import org.jetbrains.kotlin.fir.expressions.FirExpressionEvaluator
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
@@ -257,7 +258,7 @@ internal class ClassDescriptorVisitorK2(
     }
 
     private fun ConeKotlinType.toNestedSwagger(): ObjectType {
-        val arrayItems = type.typeArguments.mapNotNull { it.type }.map {
+        val arrayItems = typeArguments.mapNotNull { it.type }.map {
             convertSubTree(it)
         }
         return ObjectType("array", items = arrayItems.firstOrNull())// list only take a single generic type
@@ -325,7 +326,7 @@ internal class ClassDescriptorVisitorK2(
             summary = summary?.accept(StringResolutionVisitor(), ""),
             descr = descr?.accept(StringResolutionVisitor(), ""),
             isRequired = required?.accept(StringResolutionVisitor(), "")?.toBooleanStrictOrNull()
-                ?: (returnTypeRef.isMarkedNullable == false)
+                ?: (returnTypeRef.coneType.isNullableAny == false)
         )
     }
 
@@ -347,7 +348,7 @@ internal class ClassDescriptorVisitorK2(
             required?.add(name) ?: run {
                 required = mutableListOf(name)
             }
-        } else if ((isRequiredFromExplicitDesc == null && fir.returnTypeRef.isMarkedNullable == false)
+        } else if ((isRequiredFromExplicitDesc == null && fir.returnTypeRef.coneType.isNullableAny == false)
             && config.deriveFieldRequirementFromTypeNullability
         ) {
             required?.add(name) ?: run {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -5,6 +5,8 @@ import io.github.tabilzad.ktor.annotations.KtorDescription
 import io.github.tabilzad.ktor.annotations.KtorResponds
 import io.github.tabilzad.ktor.visitors.KtorDescriptionBag
 import io.github.tabilzad.ktor.visitors.toSwaggerType
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
@@ -17,14 +19,13 @@ import org.jetbrains.kotlin.fir.resolve.firClassLike
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
-import org.jetbrains.kotlin.ir.util.IrMessageLogger
 import org.jetbrains.kotlin.util.PrivateForInline
 
 internal class ExpressionsVisitorK2(
     private val config: PluginConfiguration,
     private val context: CheckerContext,
     private val session: FirSession,
-    private val log: IrMessageLogger
+    private val log: MessageCollector,
 ) : FirDefaultVisitor<List<KtorElement>, KtorElement?>() {
 
     init {
@@ -165,8 +166,9 @@ internal class ExpressionsVisitorK2(
         }
 
         val values = expression.arguments
-            .filterIsInstance<FirLiteralExpression<String>>()
+            .filterIsInstance<FirLiteralExpression>()
             .map { it.value }
+            .filterIsInstance<String>()
 
         return names.zip(values).toMap()
     }
@@ -286,7 +288,7 @@ internal class ExpressionsVisitorK2(
                         resultElement = endPoint
                         data.children.add(endPoint)
                     } else {
-                        log.report(IrMessageLogger.Severity.WARNING, "Endpoints cant have Endpoint as routes", null)
+                        log.report(CompilerMessageSeverity.WARNING, "Endpoints cant have Endpoint as routes", null)
                     }
                 }
             }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.resolve.fqName
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirEnumEntrySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
@@ -95,15 +96,6 @@ internal val FirElement.allChildren: MutableSet<FirElement>
         val elements = mutableSetOf<FirElement>()
         acceptChildren(AllNestedNodeCollector(elements))
         return elements
-    }
-
-
-internal val FirTypeRef.getKotlinTypeFqName
-    get(): String? {
-        // Ensure the type is resolved
-        val coneType = coneTypeSafe<ConeKotlinType>() ?: return null
-        val classId = coneType.classId
-        return classId?.internalName
     }
 
 fun FirFunction.hasAnnotation(session: FirSession, name: String): Boolean {
@@ -200,7 +192,7 @@ fun ConeKotlinType.isMap(): Boolean {
 
 private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?): Boolean {
     if (this !is ConeClassLikeType) return false
-    return lookupTag.classId == classId && (isNullable == null || type.isNullable == isNullable)
+    return lookupTag.classId == classId && (isNullable == null || this.isNullableAny == isNullable)
 }
 
 fun FirRegularClassSymbol.resolveEnumEntries(): List<String> {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/RespondsAnnotationVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/RespondsAnnotationVisitor.kt
@@ -17,11 +17,11 @@ internal class RespondsAnnotationVisitor : FirDefaultVisitor<List<KtorK2Response
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: KtorK2ResponseBag?): List<KtorK2ResponseBag> {
 
 
-        val status = functionCall.resolvedArgumentMapping?.findValueOfField("status") as? FirLiteralExpression<*>
+        val status = functionCall.resolvedArgumentMapping?.findValueOfField("status") as? FirLiteralExpression
         val type = functionCall.resolvedArgumentMapping?.findValueOfField("type") as? FirGetClassCall
-        val isCollection = functionCall.resolvedArgumentMapping?.findValueOfField("isCollection") as? FirLiteralExpression<*>
+        val isCollection = functionCall.resolvedArgumentMapping?.findValueOfField("isCollection") as? FirLiteralExpression
         val description =
-            functionCall.resolvedArgumentMapping?.findValueOfField("description") as? FirLiteralExpression<*>
+            functionCall.resolvedArgumentMapping?.findValueOfField("description") as? FirLiteralExpression
 
 
         return listOf(

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringArrayLiteralVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringArrayLiteralVisitor.kt
@@ -13,7 +13,7 @@ internal class StringArrayLiteralVisitor : FirDefaultVisitor<List<String>, List<
         return emptyList()
     }
 
-    override fun <T> visitLiteralExpression(literalExpression: FirLiteralExpression<T>, data: List<String>): List<String> =
+    override fun visitLiteralExpression(literalExpression: FirLiteralExpression, data: List<String>): List<String> =
         listOf(literalExpression.value.toString())
 
     override fun visitArrayLiteral(arrayLiteral: FirArrayLiteral, data: List<String>): List<String> {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringResolutionVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringResolutionVisitor.kt
@@ -14,6 +14,6 @@ class StringResolutionVisitor : FirDefaultVisitor<String, String>() {
             data + dr.accept(this, data)
         } ?: data
 
-    override fun <T> visitLiteralExpression(literalExpression: FirLiteralExpression<T>, data: String): String =
+    override fun visitLiteralExpression(literalExpression: FirLiteralExpression, data: String): String =
         literalExpression.value.toString()
 }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/SwaggerDeclarationChecker.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/SwaggerDeclarationChecker.kt
@@ -6,6 +6,7 @@ import io.github.tabilzad.ktor.buildPluginConfiguration
 import io.github.tabilzad.ktor.convertInternalToOpenSpec
 import io.github.tabilzad.ktor.serializeAndWriteTo
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.messageCollector
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
@@ -13,7 +14,6 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
-import org.jetbrains.kotlin.ir.util.irMessageLogger
 
 
 /**
@@ -26,7 +26,7 @@ class SwaggerDeclarationChecker(
     configuration: CompilerConfiguration
 ) : FirSimpleFunctionChecker(MppCheckerKind.Common) {
 
-    private val log = configuration.irMessageLogger
+    private val log = configuration.messageCollector
     private val config = configuration.buildPluginConfiguration()
 
     override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.tabilzad
-VERSION_NAME=0.6.0-alpha
+VERSION_NAME=0.7.4-alpha
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlinVersion = "2.0.0"
+kotlinVersion = "2.1.20"
 classgraph = "4.8.157"
 jacksonVersion = "2.15.2"
 ktorVersion = "2.2.4"


### PR DESCRIPTION
- JVMConfigurationKeys.IR has been removed (the JVM backend is no longer supported) so don't set it
  - See https://github.com/JetBrains/kotlin/commit/2a3802845c344dc3501c7fbfd476a6ee35803e4d
- Bump to Kotlin 2.1.20
